### PR TITLE
DEVOPS-1221 Adding drone release tagging stage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,7 +44,6 @@ pipeline:
     repo: quay.io/mongodb/drone-helm
     tags:
       - git-${DRONE_COMMIT_SHA:0:7}
-      - latest
     when:
       event: push
 


### PR DESCRIPTION
 * Adds git sha tagging for build/push stages
 * Adds tagging for release stage.